### PR TITLE
adding correct docker port and better docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN ls -al src
 RUN bun install --ignore-scripts
 
 # run the app
+EXPOSE 8080/tcp
 EXPOSE 3000/tcp
+
 ENTRYPOINT [ "bun", "run", "index.ts" ]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Opening a tunnel to the fly.io instance:
 fly proxy 10022:22 -a $YOUR_APP_NAME $APP_IP_ADDR 
 ```
 
+Start SFTP session to move creds:
+```bash
+sftp -o "StrictHostKeyChecking=no" \
+            -o "UserKnownHostsFile=/dev/null" \
+            -P 10022 -i ~/.ssh/flytmp root@localhost
+```
+
 
 
 ## Development Steps


### PR DESCRIPTION
### TL;DR

Updated Dockerfile to expose port 8080 and added SFTP session instructions to README.

### What changed?

- In the Dockerfile:
  - Added `EXPOSE 8080/tcp` to expose port 8080
- In the README:
  - Added instructions for starting an SFTP session to move credentials

### How to test?

1. Build the Docker image and verify that port 8080 is exposed
2. Follow the new SFTP instructions in the README to ensure successful connection and file transfer

### Why make this change?

- Exposing port 8080 allows for additional services or applications to be accessed through this port
- Adding SFTP instructions provides a secure method for transferring credentials to the fly.io instance, improving the deployment process and security