### PR TITLE
Add file download support for CoT attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,8 +174,9 @@ dist
 # Finder (MacOS) folder config
 .DS_Store
 
-key.pem
-cert.pem
+*.pem
+*.key
+*.p12
 **/config.toml
 adapter-db/
 yourdb/
@@ -183,3 +184,6 @@ yourdb/
 config.docker.toml
 config.fly.toml
 db/*/**
+
+.tak_downloads/** 
+

--- a/examples/cots/examples.xml
+++ b/examples/cots/examples.xml
@@ -24,3 +24,15 @@
     <NodeCoT-12.6.0>2024-10-24T23:10:01.693Z</NodeCoT-12.6.0></_flow-tags_>
 </detail>
 </event>
+
+
+<event version="2.0" uid="71b28985-415f-4cda-a494-04451ff259ad" type="b-f-t-r" how="h-e" time="2024-10-26T16:07:26Z" start="2024-10-26T16:07:26Z" stale="2024-10-26T16:07:36Z">
+    <point lat="-58.90375561" lon="-123.15202048" hae="NaN" ce="NaN" le="NaN"/>
+    <detail>
+        <fileshare filename="20241027_000624.jpg.zip" senderUrl="https://149.248.208.79:8443/Marti/sync/content?hash=f75249ecf45dbde4dfb7c0644efccad371ff33e583cfbc81e26f044a13df060a" sizeInBytes="3256275" sha256="f75249ecf45dbde4dfb7c0644efccad371ff33e583cfbc81e26f044a13df060a" senderUid="ANDROID-352330081248960" senderCallsign="SCORE" name="20241027_000624.jpg"/>
+        <ackrequest uid="f5743c9e-e2bc-48a0-9ed1-6906368aab72" ackrequested="true" tag="20241027_000624.jpg"/>
+        <_flow-tags_ TAK-Server-3abc9530735f4a3093430a1334481205="2024-10-26T16:07:26Z">
+            <NodeCoT-12.6.0>2024-10-26T16:07:26.830Z</NodeCoT-12.6.0>
+        </_flow-tags_>
+    </detail>
+</event>


### PR DESCRIPTION
### TL;DR

Added file sharing functionality and updated GraphQL schema to support file downloads.

### What changed?

- Updated `.gitignore` to exclude additional file types and directories.
- Added a new CoT event example with file sharing details in `examples/cots/examples.xml`.
- Implemented file download functionality in the `Producer` class:
  - Added `getFileFromTak` method to download files from TAK server.
  - Created `getFileShare` method to retrieve file content.
- Extended GraphQL schema to include file sharing and download capabilities:
  - Added `CoTFileShare` type and included it in `CoTDetail`.
  - Created a new `File` type for file downloads.
  - Added `downloadFile` query to the schema.
- Updated the GraphQL resolver to handle file downloads.

### How to test?

1. Send a CoT message with file sharing details.
2. Use the GraphQL API to query for CoTs and verify that file sharing information is included.
3. Test the `downloadFile` query by providing a valid UID of a CoT with file sharing:
   ```graphql
   query {
     downloadFile(uid: "example-uid") {
       uid
       filename
       content
     }
   }
   ```
4. Verify that the file content is returned as a base64 encoded string.

### Why make this change?

This change enhances the functionality of the system by allowing file sharing between TAK clients and the ability to download shared files through the GraphQL API. This feature is crucial for scenarios where users need to exchange images, documents, or other files within the TAK ecosystem.