### PR TITLE
adding in try catch for json parsing error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,8 +182,8 @@ adapter-db/
 yourdb/
 ./**/*.mdb
 config.docker.toml
-config.fly.toml
+config.fly.toml.bk
 db/*/**
 
 .tak_downloads/** 
-
+config.fly.toml*

--- a/src/adapters/consumer/index.ts
+++ b/src/adapters/consumer/index.ts
@@ -78,7 +78,15 @@ export class Consumer {
                 variables: new Object(this.config.consumer!.catalyst_query_variables)
             }),
         })
-        return  await result.json()
+        try {
+            return await result.json()
+        } catch (error) {
+            console.error("Error parsing response", error)
+            console.error("query", this.config.consumer!.catalyst_query)
+            console.error("variables", this.config.consumer!.catalyst_query_variables)
+            console.error("response", result)
+            return {data: {}}
+        }
     }
 
     async jsonToGeoChat(json: any): Promise<CoT[]> {


### PR DESCRIPTION
### TL;DR
Added error handling for JSON parsing in the Catalyst query consumer and updated gitignore patterns for fly.toml files.

### What changed?
- Added try-catch block around JSON parsing in the consumer adapter
- Added detailed error logging when JSON parsing fails, including the query, variables, and raw response
- Updated .gitignore to handle different variations of fly.toml files
- Added fallback return of empty data object when parsing fails

### How to test?
1. Configure an invalid or malformed Catalyst query
2. Run the consumer
3. Verify that the error is properly logged with query details
4. Confirm the system continues to operate with the fallback empty data response

### Why make this change?
To improve system resilience by gracefully handling JSON parsing failures in the Catalyst query consumer. This prevents the application from crashing when receiving malformed responses and provides better debugging information when issues occur.