### PR TITLE
feat(cot-rtsp-data): added new rtsp __video field to COT messages

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,6 +36,9 @@ export interface Config {
     catalyst_lon: number;
     group: string;
     role: string;
+    catalyst_rtsp_url: string;
+    catalyst_rtsp_port: string;
+    catalyst_rtsp_stream_path: string;
   };
   consumer?: {
     catalyst_endpoint: string;

--- a/src/tak/index.ts
+++ b/src/tak/index.ts
@@ -1,62 +1,69 @@
 import fs from "fs";
-import {Config} from "../config";
-import TAK, {CoT} from "@tak-ps/node-tak";
+import { Config } from "../config";
+import TAK, { CoT } from "@tak-ps/node-tak";
 
 export function readKeyAndCert(config: Config) {
-    // Read key and cert from file system
-    return {
-        key: fs.readFileSync(config.tak.key_file).toString(),
-        cert: fs.readFileSync(config.tak.cert_file).toString()
-    };
+  // Read key and cert from file system
+  return {
+    key: fs.readFileSync(config.tak.key_file).toString(),
+    cert: fs.readFileSync(config.tak.cert_file).toString(),
+  };
 }
 
 export class TakClient {
-    tak?: TAK;
-    config: Config;
-    timers: Map<string, Timer>
-    constructor(config: Config) {
-        this.config = config;
-        this.timers = new Map<string, Timer>();
-    }
+  tak?: TAK;
+  config: Config;
+  timers: Map<string, Timer>;
+  constructor(config: Config) {
+    this.config = config;
+    this.timers = new Map<string, Timer>();
+  }
 
-    async init() {
-        this.tak = await TAK.connect('ConnectionID', new URL(this.config.tak.endpoint), readKeyAndCert(this.config));
-    }
+  async init() {
+    this.tak = await TAK.connect(
+      this.config.tak.connection_id || "ConnectionID",
+      new URL(this.config.tak.endpoint),
+      readKeyAndCert(this.config),
+    );
+  }
 
-    async start(
-        hooks: {
-            onCoT?: (cot: CoT) => Promise<void>
-            onPing?: () => Promise<void>
+  async start(hooks: {
+    onCoT?: (cot: CoT) => Promise<void>;
+    onPing?: () => Promise<void>;
+  }) {
+    if (!this.tak) {
+      throw new Error(
+        "TAK not initialized or connection - please see logs above",
+      );
+    }
+    this.tak
+      .on("cot", async (cot: CoT) => {
+        if (hooks.onCoT) {
+          await hooks.onCoT(cot);
         }
-    ) {
-        if (!this.tak) {
-            throw new Error('TAK not initialized or connection - please see logs above');
+      })
+      .on("end", async () => {
+        console.error(`Connection End`);
+      })
+      .on("timeout", async () => {
+        console.error(`Connection Timeout`);
+      })
+      .on("ping", async () => {
+        console.error(`TAK Server Ping`);
+        if (hooks.onPing) {
+          await hooks.onPing();
         }
-        this.tak.on('cot', async (cot: CoT) => {
-            if(hooks.onCoT) {
-                await hooks.onCoT(cot);
-            }
-        }).on('end', async () => {
-            console.error(`Connection End`);
-        }).on('timeout', async () => {
-            console.error(`Connection Timeout`);
-        }).on('ping', async () => {
-            console.error(`TAK Server Ping`);
-            if(hooks.onPing) {
-                await hooks.onPing();
-            }
-        }).on('error', async (err) => {
-            console.error(`Connection Error`);
-        });
-    }
+      })
+      .on("error", async (err: Error) => {
+        console.error(`Connection Error`, err);
+      });
+  }
 
-    setInterval(name: string, func: (tak: TAK) => Bun.TimerHandler, ms: number) {
-        this.timers.set(name, setInterval(func(this.tak!), ms));
-    }
+  setInterval(name: string, func: (tak: TAK) => Bun.TimerHandler, ms: number) {
+    this.timers.set(name, setInterval(func(this.tak!), ms));
+  }
 
-    cancelInterval(name: string) {
-        this.timers.get(name)?.unref();
-    }
-
+  cancelInterval(name: string) {
+    this.timers.get(name)?.unref();
+  }
 }
-


### PR DESCRIPTION
### TL;DR

Added RTSP video streaming support to CoT messages and improved error handling.

### What changed?

- Added RTSP video streaming metadata to CoT messages with configurable URL, port, and stream path
- Created a reusable `generateCallsignHeartbeatCoT` function to standardize CoT creation
- Added error handling for CoT message transmission
- Improved logging for consumer operations
- Only initialize the producer when a catalyst app ID is provided
- Added ESLint directives to suppress warnings in specific cases
- Fixed array initialization to use `const` instead of `let` where appropriate

### How to test?

1. Configure RTSP settings in the TAK configuration:
   ```
   catalyst_rtsp_url: "your-rtsp-server:port"
   catalyst_rtsp_port: "port"
   catalyst_rtsp_stream_path: "/stream"
   ```
2. Ensure the producer has a valid `catalyst_app_id` configured
3. Run the application and verify that CoT messages include video stream information
4. Check that the consumer correctly polls and processes data at the configured interval

### Why make this change?

This change enables video streaming capabilities within the TAK ecosystem, allowing users to view live video feeds directly in their TAK clients. The improved error handling and logging make the system more robust and easier to debug, while the code refactoring improves maintainability and readability.