### PR TITLE
fix(tests): unit testing fixed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 bunx lint-staged
 
-bun test || echo "Tests failed, but commit will proceed."
+bun test

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ while (config === undefined) {
 
 let consumer: Consumer | undefined = undefined;
 let producer: Producer | undefined = undefined;
-if (config.consumer) {
+if (config.consumer?.catalyst_token) {
   consumer = new Consumer(config);
 }
 

--- a/src/adapters/consumer/index.ts
+++ b/src/adapters/consumer/index.ts
@@ -22,6 +22,13 @@ interface CoTValues {
   remarks?: string;
 }
 
+function toStr(
+  val: string | number | boolean | undefined | null,
+): string | undefined {
+  if (val === undefined || val === null) return undefined;
+  return String(val);
+}
+
 export class Consumer {
   config: Config;
   poll_interval_ms: number;
@@ -361,42 +368,49 @@ export class Consumer {
   ): CoTValues | undefined {
     // let uid, type, lat, lon, hae, how, callsign, remarks: string | undefined
     let uid, type, lat, lon, hae, how, callsign, remarks: string | undefined;
-    if (transform.uid && ld.get(object, transform.uid))
+    if (transform.uid && ld.get(object, transform.uid) !== undefined)
       uid = ld.get(object, transform.uid);
-    if (transform.type && ld.get(object, transform.type))
+    if (transform.type && ld.get(object, transform.type) !== undefined)
       type = ld.get(object, transform.type);
-    if (transform.how && ld.get(object, transform.how))
+    if (transform.how && ld.get(object, transform.how) !== undefined)
       how = ld.get(object, transform.how);
 
-    if (transform.lat && ld.get(object, transform.lat))
+    if (transform.lat && ld.get(object, transform.lat) !== undefined)
       lat = ld.get(object, transform.lat);
     else {
       console.error(`lat value not found for ${key}:${uid}`);
       return undefined;
     }
-    if (transform.lon && ld.get(object, transform.lon))
+    if (transform.lon && ld.get(object, transform.lon) !== undefined)
       lon = ld.get(object, transform.lon);
     else {
       console.error(`lon value not found for ${key}:${uid}`);
       return undefined;
     }
-    if (transform.hae && ld.get(object, transform.hae))
+    if (transform.hae && ld.get(object, transform.hae) !== undefined) {
       hae = ld.get(object, transform.hae);
+    }
 
-    if (transform.callsign && ld.get(object, transform.callsign))
+    if (
+      transform.callsign &&
+      ld.get(object, transform.callsign) !== undefined
+    ) {
       callsign = ld.get(object, transform.callsign);
+    }
 
-    if (transform.remarks && ld.get(object, transform.remarks))
+    if (transform.remarks && ld.get(object, transform.remarks) !== undefined) {
       remarks = ld.get(object, transform.remarks);
+    }
+
     return {
-      uid: uid,
-      type: type,
-      lat: lat,
-      lon: lon,
-      hae: hae,
-      callsign: callsign,
-      how: how,
-      remarks: remarks,
+      uid: toStr(uid),
+      type: toStr(type),
+      lat: toStr(lat),
+      lon: toStr(lon),
+      hae: toStr(hae),
+      callsign: toStr(callsign),
+      how: toStr(how),
+      remarks: toStr(remarks),
     };
   }
 

--- a/tests/product.spec.ts
+++ b/tests/product.spec.ts
@@ -1,14 +1,26 @@
-import { expect, test, describe, it} from "bun:test";
-import {getConfig} from "../src/config";
-import {Producer} from "../src/adapters/producer"
-import {CoT} from "@tak-ps/node-tak";
+import { expect, describe, it } from "bun:test";
+import { Config } from "../src/config";
+import { Producer } from "../src/adapters/producer";
+import { CoT } from "@tak-ps/node-tak";
 
 describe("Producer", () => {
-    describe("local storage", () => {
-        const config = getConfig()
-        console.log(config)
+  describe("local storage", () => {
+    // missing tak and consumer fields
+    // @ts-expect-error: This is a mock config, missing fields are intentional
+    const mockConfig: Config = {
+      dev: true,
+      producer: {
+        catalyst_jwks_endpoint: "https://catalyst.devintelops.io/jwks",
+        catalyst_app_id: "test-app-id",
+        local_db_path: ".tak_downloads",
+        local_download_path: ".tak_downloads",
+        graphql_port: 4000,
+        graphql_host: "localhost",
+      },
+    };
+    console.log(mockConfig);
 
-        const exampleCoT = new CoT(`
+    const exampleCoT = new CoT(`
             <event version="2.0" uid="a4f460" type="a-f-G-U-C" how="h-g-i-g-o" time="2024-10-16T19:52:25.747Z" start="2024-10-16T19:52:25.747Z" stale="2024-10-16T19:57:25.747Z">
                 <point lat="38.804169" lon="-76.136627" hae="1575" ce="999999.0" le="999999.0"/>
                 <detail>
@@ -16,45 +28,44 @@ describe("Producer", () => {
                      <NodeCoT-12.6.0>2024-10-16T19:52:25.747Z</NodeCoT-12.6.0>
                     </_flow-tags_>
                 </detail>
-            </event>`)
+            </event>`);
 
+    it("should initialize the database", () => {
+      const producer = new Producer(mockConfig);
+      expect(producer.db).toBeDefined();
+    });
 
-        it ("should initialize the database", () => {
-            const producer = new Producer(config)
-            expect(producer.db).toBeDefined()
-        })
+    it("should close the database", async () => {
+      const producer = new Producer(mockConfig);
+      await producer.closeDB();
+      try {
+        producer.db.get("doesntexist");
+      } catch (e) {
+        expect(e).toBeDefined();
+      }
+    });
 
-        it('should close the database', async () => {
-            const producer = new Producer(config)
-            await producer.closeDB()
-            try {
-                producer.db.get("doesntexist")
-            } catch (e) {
-                expect(e).toBeDefined()
-            }
-        })
+    it("should put/get a CoT in the database", async () => {
+      const producer = new Producer(mockConfig);
+      await producer.putCoT(exampleCoT);
+      const result = producer.getCoT("a4f460");
+      Bun.deepEquals(result, exampleCoT.raw, true);
+    });
 
-        it('should put/get a CoT in the database', async () => {
-            const producer = new Producer(config)
-            await producer.putCoT(exampleCoT)
-            const result = producer.getCoT("a4f460")
-            Bun.deepEquals(result, exampleCoT.raw, true)
-        })
+    it("should delete a CoT from the database", async () => {
+      const producer = new Producer(mockConfig);
+      await producer.putCoT(exampleCoT);
+      await producer.deleteCoT("a4f460");
 
-        it("should delete a CoT from the database", async () => {
-            const producer = new Producer(config)
-            await producer.putCoT(exampleCoT)
-            await producer.deleteCoT("a4f460")
+      const shouldBeDeleted = producer.db.get("a4f460");
+      expect(shouldBeDeleted).toBeUndefined();
+    });
 
-            const shouldBeDeleted =    producer.db.get("a4f460")
-            expect(shouldBeDeleted).toBeUndefined()
-        })
-
-        it("should get all CoTs from the database", async () => {
-            const producer = new Producer(config)
-            await producer.putCoT(exampleCoT)
-            const allCots = producer.getAllCoT()
-            Bun.deepEquals(allCots, [exampleCoT.raw], true)
-        })
-    })
-})
+    it("should get all CoTs from the database", async () => {
+      const producer = new Producer(mockConfig);
+      await producer.putCoT(exampleCoT);
+      const allCots = producer.getAllCoT();
+      Bun.deepEquals(allCots, [exampleCoT.raw], true);
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Fixed data handling in the Consumer adapter and improved test reliability by making tests fail the pre-commit hook.

### What changed?

- Modified the pre-commit hook to fail when tests fail (removed the override that allowed commits despite test failures)
- Added a `toStr()` helper function to properly handle type conversion for CoT values
- Fixed the Consumer initialization to only create a consumer when a catalyst token is present
- Updated the `extractCoTValues` method to properly handle undefined, null, and falsy values (like 0)
- Improved test cases with proper mock configurations and more accurate test data

### How to test?

1. Run `bun test` to verify all tests pass
2. Try committing with failing tests to confirm the pre-commit hook prevents the commit
3. Test the consumer with various data inputs, including edge cases with falsy values (0, empty strings)

### Why make this change?

The previous implementation had issues with handling falsy values in CoT data extraction, causing valid data like `0` for latitude/longitude to be rejected. This change ensures proper type handling and validation of CoT values. Additionally, making tests mandatory in the pre-commit hook improves code quality by preventing commits with failing tests.