### PR TITLE
chore: error proofing for config inputs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -102,7 +102,7 @@ function generateCallsignHeartbeatCoT({
   group?: string;
   role?: string;
 }): CoT | null {
-  if (!lat || !lon) {
+  if (lat === undefined || lon === undefined) {
     console.error(
       "generateCallsignHeartbeatCoT: local heartbeat lat and lon are required. could not send Heartbeat",
     );
@@ -147,8 +147,8 @@ takClient.setInterval(
         callsign: "CATALYST-TAK-ADAPTER",
         type: "a-f-G-U-C-I",
         how: "m-g",
-        lat: config?.tak.catalyst_lat,
-        lon: config?.tak.catalyst_lon,
+        lat: config?.tak.catalyst_lat ?? 0.0,
+        lon: config?.tak.catalyst_lon ?? 0.0,
         group: config?.tak.group,
         role: config?.tak.role,
       });

--- a/src/adapters/producer/index.ts
+++ b/src/adapters/producer/index.ts
@@ -401,7 +401,8 @@ export class Producer {
                         groupOwner:
                           cot.event.detail?.__chat._attributes.groupOwner,
                         messageId:
-                          cot.event.detail?.__chat._attributes.messageId,
+                          cot.event.detail?.__chat._attributes.messageId ??
+                          cot.event._attributes.uid,
                         chatRoom: cot.event.detail?.__chat._attributes.chatroom,
                         id: cot.event.detail?.__chat._attributes.id,
                         senderCallsign:


### PR DESCRIPTION
### TL;DR

Fixed coordinate validation and improved fallback handling for TAK adapter.

### What changed?

- Fixed the coordinate validation in `generateCallsignHeartbeatCoT` to properly check for `undefined` values instead of falsy values
- Added fallback to `0.0` for catalyst latitude and longitude when not provided in the config
- Added a fallback for chat message IDs to use the event UID when the messageId attribute is missing

### How to test?

1. Test the TAK adapter with missing or zero coordinate values to ensure it handles them correctly
2. Verify chat messages are properly processed even when messageId is missing
3. Confirm heartbeats are sent with fallback coordinates (0.0, 0.0) when config values are missing

### Why make this change?

These changes improve the robustness of the TAK adapter by properly handling edge cases:
- The previous coordinate check would reject valid `0.0` values as falsy
- Missing coordinates in config would cause errors instead of using sensible defaults
- Chat messages without explicit messageIds would fail to process properly