### PR TITLE
feat: add datadog monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-# use the official Bun image
-# see all versions at https://hub.docker.com/r/oven/bun/tags
-FROM oven/bun:1-debian AS base
+# syntax=docker/dockerfile:1
+ARG BUN_VERSION=1.2.22
+
+FROM gcr.io/datadoghq/agent:7 AS datadogagent
+
+# Adjust BUN_VERSION as desired
+FROM oven/bun:${BUN_VERSION}-slim AS base
+
+LABEL fly_launch_runtime="Bun"
 
 WORKDIR /app
 
 ENV NODE_ENV=production
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential pkg-config python-is-python3 ca-certificates
 
 # TS dependencies
 COPY package.json .
@@ -15,9 +28,29 @@ RUN bun install --ignore-scripts
 # copy source code
 COPY index.ts .
 COPY src/ src/
+COPY entrypoint.sh .
 
 # copy config file
 COPY config.toml .
+
+# Final stage for app image
+FROM base
+
+# CA certs fix for TLS (prevents x509 unknown authority)
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Copy Datadog Agent into this image and the /etc config skeleton
+COPY --from=datadogagent /opt/datadog-agent /opt/datadog-agent
+COPY --from=datadogagent /etc/datadog-agent /etc/datadog-agent
+
+# Copy Datadog config files
+COPY datadog/system-probe.yaml /etc/datadog-agent/system-probe.yaml
+COPY datadog/datadog.yaml /etc/datadog-agent/datadog.yaml
+COPY datadog/security-agent.yaml /etc/datadog-agent/security-agent.yaml
+
+# Copy built application
+COPY --from=build /app /app
+COPY --from=build /app/entrypoint.sh /entrypoint.sh
 
 ARG TAK_CERT_FILE=tak-admin.cert.pem
 ARG TAK_KEY_FILE=tak-admin.key.pem
@@ -25,11 +58,14 @@ ARG TAK_KEY_FILE=tak-admin.key.pem
 COPY ${TAK_CERT_FILE} ./${TAK_CERT_FILE}
 COPY ${TAK_KEY_FILE} ./${TAK_KEY_FILE}
 
-RUN chown -R bun:bun /app
-USER bun
+RUN chmod +x /entrypoint.sh
 
-# run the app
 EXPOSE 8080/tcp
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD ["curl", "-f", "http://localhost:8080/health", "||", "exit", "1"]
+
+# Start the server by default, this can be overwritten at runtime
 EXPOSE 3000/tcp
 
-ENTRYPOINT [ "bun", "run", "index.ts" ]
+# Simple entrypoint that starts Agent + your app
+ENTRYPOINT ["/entrypoint.sh"]

--- a/datadog/datadog.yaml
+++ b/datadog/datadog.yaml
@@ -1,0 +1,4 @@
+process_config:
+  enabled: "false"
+hostname_fqdn: true
+cloud_provider_metadata: []

--- a/datadog/security-agent.yaml
+++ b/datadog/security-agent.yaml
@@ -1,0 +1,4 @@
+runtime_security_config:
+  enabled: true
+  ebpfless:
+    enabled: true

--- a/datadog/system-probe.yaml
+++ b/datadog/system-probe.yaml
@@ -1,0 +1,4 @@
+runtime_security_config:
+  enabled: true
+  ebpfless:
+    enabled: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Start the agent pieces you need
+/opt/datadog-agent/bin/agent/agent run -c /etc/datadog-agent &
+sleep 5
+# 2) Wait until the Agent’s IPC (port 5001) responds to the CLI
+for i in {1..120}; do
+  if /opt/datadog-agent/bin/agent/agent status >/dev/null 2>&1; then
+    echo "[ok] Datadog Agent IPC is up"
+    break
+  fi
+  sleep 1
+  if [[ $i -eq 120 ]]; then
+    echo "[err] Agent did not come up in time" >&2
+    tail -n 100 /var/log/dd-agent.log || true
+    exit 1
+  fi
+done
+# Start system-probe (no eBPF programs loaded in this mode; it just brokers events)
+# If Datadog’s package expects it:
+if command -v /opt/datadog-agent/embedded/bin/system-probe >/dev/null; then
+  /opt/datadog-agent/embedded/bin/system-probe &
+fi
+# Start system-probe (no eBPF programs loaded in this mode; it just brokers events)
+# If Datadog’s package expects it:
+if command -v /opt/datadog-agent/embedded/bin/security-agent >/dev/null; then
+  /opt/datadog-agent/embedded/bin/security-agent start &
+fi
+# Wrap your app so ptrace can observe it (recommended "wrap" mode)
+exec /opt/datadog-agent/embedded/bin/cws-instrumentation trace -- bun run start

--- a/fly.toml
+++ b/fly.toml
@@ -7,11 +7,33 @@ app = 'catalyst-tak-adapter'
 primary_region = 'ord'
 
 [build]
-  dockerfile = 'Dockerfile'
+  dockerfile = "Dockerfile"
 
 [env]
   CONFIG_PATH = 'config.toml'
   NODE_ENV = 'production'
+  DD_TRACE_REPORT_HOSTNAME = "true"
+  DD_SERVICE = "catalyst-tak-adapter"
+  DD_ENV = "prod"
+  DD_VERSION = "1.0.0"
+  DD_APM_ENABLED = 'true'
+  DD_APM_INSTRUMENTATION_ENABLED = 'true'
+  DD_DOGSTATSD_NON_LOCAL_TRAFFIC = 'false'
+  DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION = 'true'
+  DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL = 'true'
+  DD_LOGS_ENABLED = 'true'
+  DD_LOGS_INJECTION = "true"
+  DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED = 'true'
+  DD_PROFILING_ENABLED = 'auto'
+  DD_RUNTIME_SECURITY_CONFIG_ENABLED = "true"
+  DD_RUNTIME_SECURITY_CONFIG_EBPFLESS_ENABLED = "true"
+  DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED = 'true'
+  DD_SBOM_CONTAINER_IMAGE_ENABLED = "true"
+  DD_SBOM_HOST_ENABLED = "true"
+  DD_SBOM_ENABLED = "true"
+  DD_SITE = 'datadoghq.com'
+  DD_SYSTEM_PROBE_ENABLED = 'true'
+  DD_TAGS = 'fly_app:catalyst-tak-adapter'
 
 [[mounts]]
   source = 'adapter_data_ord'
@@ -24,6 +46,20 @@ primary_region = 'ord'
   auto_start_machines = true
   min_machines_running = 1
   processes = ['app']
+
+[[services]]
+  internal_port = 8125
+  processes = ["app"]
+  protocol = "udp"
+  [[services.ports]]
+    port = 8125
+    
+[[services]]
+  internal_port = 8126
+  processes = ["app"]
+  protocol = "tcp"
+  [[services.ports]]
+    port = "8126"
 
 [[vm]]
   memory = '2gb'


### PR DESCRIPTION
### TL;DR

Integrated Datadog monitoring and observability into the TAK adapter service.

### What changed?

- Updated Dockerfile to use a multi-stage build process with Datadog agent integration
- Added Datadog configuration files for monitoring and security
- Created an entrypoint script to properly initialize both Datadog agents and the application
- Added health check to the container
- Configured fly.toml with Datadog environment variables and additional service ports
- Switched to a slim Bun image with a configurable version

### How to test?

1. Deploy the application to Fly.io
2. Verify the application starts correctly with `fly logs`
3. Check Datadog dashboard to confirm metrics, logs, and traces are being received
4. Test the health check endpoint at `/health`
5. Verify security monitoring is active in Datadog Security dashboard

### Why make this change?

This change adds comprehensive monitoring and observability to the TAK adapter service using Datadog. The integration provides:

- Application performance monitoring (APM)
- Log collection and analysis
- Security monitoring with runtime protection
- Container health checks
- Software bill of materials (SBOM) scanning
- Profiling capabilities

These improvements will help identify issues faster, improve reliability, and enhance security posture of the service.