### PR TITLE
feat: add COT_LOG_REGEX env var for filtered CoT debug logging

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -146,7 +146,9 @@ const ConfigSchema = z.object({
 
 export type ConsumerConfig = z.infer<typeof ConsumerConfigSchema>;
 export type TakConfig = z.infer<typeof TakConfigSchema>;
-export type Config = z.infer<typeof ConfigSchema>;
+export type Config = z.infer<typeof ConfigSchema> & {
+  cot_log_regex?: string;
+};
 export type CoTTransform = z.infer<typeof CoTTransformSchema>;
 export type CoTOverwrite = z.infer<typeof CoTOverwriteSchema>;
 
@@ -169,6 +171,10 @@ export function getConfig(): Config {
   if (process.env.NODE_ENV !== "development") {
     console.log("[CONFIG] NODE_ENV is not development, setting dev to false");
     validatedConfig.dev = false;
+  }
+
+  if (process.env.COT_LOG_REGEX) {
+    validatedConfig.cot_log_regex = process.env.COT_LOG_REGEX;
   }
 
   console.log("[CONFIG] validatedConfig", validatedConfig);

--- a/src/tak/index.ts
+++ b/src/tak/index.ts
@@ -3,6 +3,16 @@ import type { Config } from "../config";
 import TAK, { CoT } from "@tak-ps/node-tak";
 import { ExponentialBackoff } from "../utils";
 
+export function buildCotLogRegex(pattern: string | undefined): RegExp | null {
+  if (!pattern) return null;
+  try {
+    return new RegExp(pattern);
+  } catch (e) {
+    console.error(`Invalid cot_log_regex: ${e}`);
+    process.exit(1);
+  }
+}
+
 export function readKeyAndCert(config: Config) {
   // Read key and cert from file system
   return {
@@ -20,11 +30,13 @@ export class TakClient {
   reconnecting: boolean = false;
   private readonly _backoff: ExponentialBackoff = new ExponentialBackoff();
   private connectionIdOverride?: string;
+  private readonly cotLogRegex: RegExp | null;
 
   constructor(config: Config, opts?: { connectionId?: string }) {
     this.config = config;
     this.timers = new Map<string, Timer>();
     this.connectionIdOverride = opts?.connectionId;
+    this.cotLogRegex = buildCotLogRegex(config.cot_log_regex);
   }
 
   async init() {
@@ -89,6 +101,9 @@ export class TakClient {
     }
     this.tak
       .on("cot", async (cot: CoT) => {
+        if (this.cotLogRegex?.test(cot.raw)) {
+          console.log("[cot_log_regex match]", cot.raw);
+        }
         if (hooks.onCoT) {
           const pos = cot.position();
           cot.position([pos[0] ?? 0, pos[1] ?? 0, pos[2] ?? 0]);

--- a/tests/cot-log-regex.spec.ts
+++ b/tests/cot-log-regex.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, spyOn } from "bun:test";
+import { buildCotLogRegex } from "../src/tak";
+
+describe("buildCotLogRegex", () => {
+  it("returns null when pattern is undefined", () => {
+    expect(buildCotLogRegex(undefined)).toBeNull();
+  });
+
+  it("returns null when pattern is empty string", () => {
+    expect(buildCotLogRegex("")).toBeNull();
+  });
+
+  it("returns a RegExp for a valid pattern", () => {
+    const regex = buildCotLogRegex("a-f-G");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex!.test("type=a-f-G-U-C")).toBe(true);
+    expect(regex!.test("type=b-t-f")).toBe(false);
+  });
+
+  it("supports full regex syntax", () => {
+    const regex = buildCotLogRegex('uid="ANDROID-.*?"');
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex!.test('uid="ANDROID-deadbeef"')).toBe(true);
+    expect(regex!.test('uid="iPhone-abc"')).toBe(false);
+  });
+
+  it("exits with code 1 for an invalid regex", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => buildCotLogRegex("[invalid")).toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
### TL;DR

Added a CoT log regex feature to selectively log CoT messages that match a specified pattern.

### What changed?

- Extended the `Config` type to include an optional `cot_log_regex` property
- Added support for setting the regex pattern via the `COT_LOG_REGEX` environment variable
- Implemented a `buildCotLogRegex` function to safely create a RegExp from the provided pattern
- Added logic in the TakClient to log CoT messages that match the configured regex
- Created comprehensive tests for the regex functionality

### How to test?

1. Set the `COT_LOG_REGEX` environment variable with a regex pattern (e.g., `export COT_LOG_REGEX='a-f-G'`)
2. Run the application and observe that only CoT messages matching the pattern are logged with the prefix `[cot_log_regex match]`
3. Try different patterns to filter specific types of CoT messages
4. Run the new tests with `bun test tests/cot-log-regex.spec.ts`

### Why make this change?

This feature enables selective debugging of CoT messages, making it easier to troubleshoot issues with specific message types without being overwhelmed by all CoT traffic. It's particularly useful in environments with high message volume where finding specific messages is challenging.