### PR TITLE
fix: addressed undefined fs during unit test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,8 +22,9 @@
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@eslint/js": "^9.31.0",
-        "@types/bun": "latest",
+        "@types/bun": "1.2.20",
         "@types/lodash": "^4.17.20",
+        "@types/node": "^25.3.0",
         "eslint": "^9.31.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.5.1",
@@ -165,7 +166,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, ""],
 
-    "@openaddresses/batch-error": ["@openaddresses/batch-error@2.8.0", "", { "dependencies": { "@types/express": "^4.17.16" } }, ""],
+    "@openaddresses/batch-error": ["@openaddresses/batch-error@2.13.1", "", { "dependencies": { "@types/express": "^5.0.0" } }, "sha512-Xvt5G6oTlz6swjVM7zeaFOLuIxf63PXkGeEvTLqns5dO2Yt/SNFNehL5rbv5tea7UYTxy0hYOEOiU3/APwCqAw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, ""],
 
@@ -193,11 +194,11 @@
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "", {}, ""],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.37", "", {}, ""],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
-    "@tak-ps/node-cot": ["@tak-ps/node-cot@12.37.0", "", { "dependencies": { "@openaddresses/batch-error": "^2.4.0", "@sinclair/typebox": "^0.34.0", "@turf/destination": "^7.2.0", "@turf/ellipse": "^7.0.0", "@turf/helpers": "^7.0.0", "@turf/point-on-feature": "^7.0.0", "@turf/sector": "^7.1.0", "@turf/truncate": "^7.0.0", "@types/archiver": "^6.0.2", "@types/geojson": "^7946.0.14", "ajv": "^8.12.0", "archiver": "^7.0.1", "color": "^5.0.0", "geomagnetism": "^0.2.0", "json-diff-ts": "^4.0.1", "milsymbol": "^3.0.2", "node-stream-zip": "^1.15.0", "protobufjs": "^7.3.0", "rimraf": "^6.0.0", "xml-js": "^1.6.11" } }, ""],
+    "@tak-ps/node-cot": ["@tak-ps/node-cot@12.37.0", "", { "dependencies": { "@openaddresses/batch-error": "^2.4.0", "@sinclair/typebox": "^0.34.0", "@turf/destination": "^7.2.0", "@turf/ellipse": "^7.0.0", "@turf/helpers": "^7.0.0", "@turf/point-on-feature": "^7.0.0", "@turf/sector": "^7.1.0", "@turf/truncate": "^7.0.0", "@types/archiver": "^6.0.2", "@types/geojson": "^7946.0.14", "ajv": "^8.12.0", "archiver": "^7.0.1", "color": "^5.0.0", "geomagnetism": "^0.2.0", "json-diff-ts": "^4.0.1", "milsymbol": "^3.0.2", "node-stream-zip": "^1.15.0", "protobufjs": "^7.3.0", "rimraf": "^6.0.0", "xml-js": "^1.6.11" } }, "sha512-Rhek4Jz01BPwAsEtPg+jP9BkOrYata+eHgtPWNrfwxl7HWfJZw6tm5xRW+kXtYsdvqlx0kvM/cx2lyFc6HL1Hg=="],
 
-    "@tak-ps/node-tak": ["@tak-ps/node-tak@9.3.2", "", { "dependencies": { "ajv": "^8.12.0", "form-data": "^4.0.2", "http-cookie-agent": "^7.0.1", "mime": "^4.0.7", "p12-pem": "^1.0.5", "pem": "^1.14.8", "tough-cookie": "^5.1.2", "undici": "^7.8.0", "xml2js": "^0.6.2" }, "peerDependencies": { "@tak-ps/node-cot": "^12.0.0" }, "bin": { "tak": "cli.ts" } }, ""],
+    "@tak-ps/node-tak": ["@tak-ps/node-tak@9.3.2", "", { "dependencies": { "ajv": "^8.12.0", "form-data": "^4.0.2", "http-cookie-agent": "^7.0.1", "mime": "^4.0.7", "p12-pem": "^1.0.5", "pem": "^1.14.8", "tough-cookie": "^5.1.2", "undici": "^7.8.0", "xml2js": "^0.6.2" }, "peerDependencies": { "@tak-ps/node-cot": "^12.0.0" }, "bin": { "tak": "cli.ts" } }, "sha512-fAIJ/fhWq5PFhWCQobuh5acFn08TVw6+JNfY9fA2EzgWAGApyDCk06kz1ggMrvL8qN75+17BNOFm/oOuDngJ4A=="],
 
     "@turf/bbox": ["@turf/bbox@7.1.0", "", { "dependencies": { "@turf/helpers": "^7.1.0", "@turf/meta": "^7.1.0", "@types/geojson": "^7946.0.10", "tslib": "^2.6.2" } }, ""],
 
@@ -243,11 +244,11 @@
 
     "@turf/truncate": ["@turf/truncate@7.1.0", "", { "dependencies": { "@turf/helpers": "^7.1.0", "@turf/meta": "^7.1.0", "@types/geojson": "^7946.0.10", "tslib": "^2.6.2" } }, ""],
 
-    "@types/archiver": ["@types/archiver@6.0.2", "", { "dependencies": { "@types/readdir-glob": "*" } }, ""],
+    "@types/archiver": ["@types/archiver@6.0.4", "", { "dependencies": { "@types/readdir-glob": "*" } }, "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.5", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, ""],
 
-    "@types/bun": ["@types/bun@1.2.22", "", { "dependencies": { "bun-types": "1.2.22" } }, "sha512-5A/KrKos2ZcN0c6ljRSOa1fYIyCKhZfIVYeuyb4snnvomnpFqC0tTsEkdqNxbAgExV384OETQ//WAjl3XbYqQA=="],
+    "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, ""],
 
@@ -255,9 +256,9 @@
 
     "@types/estree": ["@types/estree@1.0.6", "", {}, ""],
 
-    "@types/express": ["@types/express@4.17.21", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "*" } }, ""],
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
 
-    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.6", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, ""],
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
 
     "@types/geojson": ["@types/geojson@7946.0.14", "", {}, ""],
 
@@ -269,7 +270,7 @@
 
     "@types/mime": ["@types/mime@1.3.5", "", {}, ""],
 
-    "@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@types/qs": ["@types/qs@6.9.16", "", {}, ""],
 
@@ -281,7 +282,7 @@
 
     "@types/send": ["@types/send@0.17.4", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, ""],
 
-    "@types/serve-static": ["@types/serve-static@1.15.7", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, ""],
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.38.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.38.0", "@typescript-eslint/type-utils": "8.38.0", "@typescript-eslint/utils": "8.38.0", "@typescript-eslint/visitor-keys": "8.38.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.38.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, ""],
 
@@ -323,7 +324,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, ""],
 
-    "agent-base": ["agent-base@7.1.4", "", {}, ""],
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, ""],
 
@@ -361,7 +362,7 @@
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, ""],
 
-    "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
+    "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, ""],
 
@@ -561,7 +562,7 @@
 
     "hono": ["hono@4.8.5", "", {}, ""],
 
-    "http-cookie-agent": ["http-cookie-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.4" }, "peerDependencies": { "tough-cookie": "^4.0.0 || ^5.0.0", "undici": "^7.0.0" } }, ""],
+    "http-cookie-agent": ["http-cookie-agent@7.0.3", "", { "dependencies": { "agent-base": "^7.1.4" }, "peerDependencies": { "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0", "undici": "^7.0.0" }, "optionalPeers": ["undici"] }, "sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": "bin.js" }, ""],
 
@@ -759,7 +760,7 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, ""],
 
-    "protobufjs": ["protobufjs@7.4.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, ""],
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, ""],
 
@@ -839,13 +840,13 @@
 
     "tinyexec": ["tinyexec@1.0.1", "", {}, ""],
 
-    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": "bin/cli.js" }, ""],
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
 
-    "tldts-core": ["tldts-core@6.1.86", "", {}, ""],
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, ""],
 
-    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, ""],
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, ""],
 
@@ -859,7 +860,7 @@
 
     "undici": ["undici@7.11.0", "", {}, ""],
 
-    "undici-types": ["undici-types@5.26.5", "", {}, ""],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unicorn-magic": ["unicorn-magic@0.1.0", "", {}, ""],
 
@@ -881,9 +882,9 @@
 
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": "bin/cli.js" }, ""],
 
-    "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, ""],
+    "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
-    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, ""],
+    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, ""],
 
@@ -1011,6 +1012,20 @@
 
     "@turf/truncate/tslib": ["tslib@2.8.0", "", {}, ""],
 
+    "@types/body-parser/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/connect/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/conventional-commits-parser/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/express-serve-static-core/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/readdir-glob/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/send/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
+    "@types/serve-static/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, ""],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, ""],
@@ -1022,6 +1037,8 @@
     "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, ""],
 
     "archiver-utils/glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, ""],
+
+    "bun-types/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
 
     "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, ""],
 
@@ -1046,6 +1063,8 @@
     "log-update/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, ""],
 
     "path-scurry/lru-cache": ["lru-cache@11.0.1", "", {}, ""],
+
+    "protobufjs/@types/node": ["@types/node@20.12.14", "", { "dependencies": { "undici-types": "~5.26.4" } }, ""],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, ""],
 
@@ -1075,6 +1094,20 @@
 
     "@tak-ps/node-tak/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, ""],
 
+    "@types/body-parser/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/connect/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/conventional-commits-parser/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/readdir-glob/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/send/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
+    "@types/serve-static/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, ""],
 
     "@typescript-eslint/utils/@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, ""],
@@ -1086,6 +1119,8 @@
     "archiver-utils/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, ""],
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, ""],
+
+    "bun-types/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, ""],
 
@@ -1102,6 +1137,8 @@
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, ""],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, ""],
+
+    "protobufjs/@types/node/undici-types": ["undici-types@5.26.5", "", {}, ""],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, ""],
 

--- a/fly-secrets.ts
+++ b/fly-secrets.ts
@@ -1,8 +1,8 @@
-import { parse } from "smol-toml";
-import { readFileSync } from "fs";
-import { join } from "path";
-import z from "zod";
 import { execSync } from "child_process";
+import { readFileSync } from "node:fs";
+import { join } from "path";
+import { parse } from "smol-toml";
+import z from "zod";
 
 const FlySecretsSchema = z.object({
   consumer: z.object({

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,9 @@
 import TAK, { CoT } from "@tak-ps/node-tak";
-import { TakClient } from "./src/tak";
-import { getConfig, Config } from "./src/config";
 import { Consumer } from "./src/adapters/consumer";
 import { Producer } from "./src/adapters/producer";
+import { Config, getConfig } from "./src/config";
 import ContactBook from "./src/modules/contact-book";
+import { TakClient } from "./src/tak";
 
 let config: Config | undefined = undefined;
 while (config === undefined) {
@@ -29,7 +29,7 @@ let producer: Producer | undefined = undefined;
 for (const consumer of config.consumers ?? []) {
   if (consumer.enabled) {
     try {
-      consumers.push(new Consumer(consumer));
+      consumers.push(new Consumer(consumer, config.tak));
     } catch (e) {
       console.error("Error instantiating consumer", e);
     }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "",
   "main": "index.ts",
   "type": "module",
+  "engines": {
+    "bun": "1.2.20"
+  },
   "scripts": {
     "start": "bun run index.ts",
-    "dev": "NODE_ENV=development bun run index.ts --watch ./src",
+    "dev": "NODE_ENV=development bun run --console-depth=10 index.ts --watch ./src",
     "config:template": "bun run src/config/index.ts",
     "test": "bun test",
     "testw": "bun test --watch",
@@ -37,7 +40,8 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
-    "@types/bun": "latest",
+    "@types/bun": "1.2.20",
+    "@types/node": "^25.3.0",
     "@types/lodash": "^4.17.20",
     "globals": "^15.15.0",
     "husky": "^9.1.7",

--- a/src/adapters/consumer/index.ts
+++ b/src/adapters/consumer/index.ts
@@ -6,17 +6,16 @@
     [X] we need to send the messages to the TAK server
  */
 
+import type TAK from "@tak-ps/node-tak";
+import { CoT } from "@tak-ps/node-tak";
+import { DatabaseOptions, open, type RootDatabase } from "lmdb";
+import ld from "lodash";
 import {
-  getConfig,
   type ConsumerConfig,
   type CoTOverwrite,
   type CoTTransform,
   type TakConfig,
 } from "../../config";
-import type TAK from "@tak-ps/node-tak";
-import { CoT } from "@tak-ps/node-tak";
-import ld from "lodash";
-import { DatabaseOptions, open, type RootDatabase } from "lmdb";
 import { createRTSPConnectionDetailItemPlugin } from "./consumer-plugins";
 
 interface CoTValues {
@@ -45,9 +44,9 @@ export class Consumer {
   dbPath: string;
   db: RootDatabase<string, Uint8Array>;
 
-  constructor(config: ConsumerConfig) {
+  constructor(config: ConsumerConfig, takConfig: TakConfig) {
     this.config = config;
-    this.takConfig = getConfig().tak;
+    this.takConfig = takConfig;
     this.dbPath = config?.local_db_path || "./db/consumer";
     const missingEnvs = [];
 

--- a/src/adapters/producer/index.ts
+++ b/src/adapters/producer/index.ts
@@ -1,15 +1,15 @@
-import CoT, { Types } from "@tak-ps/node-cot";
-import { DatabaseOptions, open, RootDatabase } from "lmdb";
-import { Config } from "../../config";
 import type { Static } from "@sinclair/typebox";
+import CoT, { Types } from "@tak-ps/node-cot";
+import { createSchema, createYoga } from "graphql-yoga";
 import { Hono } from "hono";
-import { createYoga, createSchema } from "graphql-yoga";
 import { createRemoteJWKSet } from "jose";
-import path from "node:path";
-import fs from "fs";
-import { readKeyAndCert } from "../../tak";
+import { DatabaseOptions, open, RootDatabase } from "lmdb";
+import * as fs from "node:fs";
 import https from "node:https";
+import path from "node:path";
 import { verifyJwtWithRemoteJwks } from "../../auth/catalyst-jwt";
+import { Config } from "../../config";
+import { readKeyAndCert } from "../../tak";
 
 type CoTMsg = Static<typeof Types.default>;
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
-import toml from "smol-toml";
-import { merge } from "lodash";
-import z from "zod";
 import { generateMock } from "@anatine/zod-mock";
+import { merge } from "lodash";
+import * as fs from "node:fs";
+import toml from "smol-toml";
+import z from "zod";
 
 // Zod schema for SecretConfig validation
 export const SecretConfigSchema = z

--- a/src/tak/index.ts
+++ b/src/tak/index.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
-import type { Config } from "../config";
 import TAK, { CoT } from "@tak-ps/node-tak";
+import * as fs from "node:fs";
+import type { Config } from "../config";
 import { ExponentialBackoff } from "../utils";
 
 export function buildCotLogRegex(pattern: string | undefined): RegExp | null {

--- a/tests/consumer.spec.ts
+++ b/tests/consumer.spec.ts
@@ -1,9 +1,9 @@
 import { Consumer } from "../src/adapters/consumer";
-import { Config, CoTTransform } from "../src/config";
 import { createRTSPConnectionDetailItemPlugin } from "../src/adapters/consumer/consumer-plugins";
+import { Config, CoTTransform } from "../src/config";
 // import TAK, { CoT } from '@tak-ps/node-tak';
 // import * as ld from 'lodash';
-import { expect, describe, beforeEach, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 describe("Consumer", () => {
   let consumer: Consumer;
@@ -40,7 +40,7 @@ describe("Consumer", () => {
   };
 
   beforeEach(() => {
-    consumer = new Consumer(mockConfig.consumers![0]!);
+    consumer = new Consumer(mockConfig.consumers![0]!, mockConfig.tak);
   });
 
   it("extracts CoT values correctly", () => {

--- a/tests/product.spec.ts
+++ b/tests/product.spec.ts
@@ -1,22 +1,62 @@
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 import * as realFs from "node:fs";
-import { expect, describe, it, afterEach, mock, afterAll } from "bun:test";
 
-// Mock fs module
-mock.module("node:fs", () => {
-  const mockWriteStream = {
-    on: mock((event, callback) => {
-      // Simulate successful events
-      if (event === "finish") {
-        setTimeout(callback, 10);
-      }
-      return mockWriteStream;
-    }),
-    close: mock(() => {}),
-    emit: mock(() => {}),
-  };
+import { CoT } from "@tak-ps/node-tak";
+import { Producer } from "../src/adapters/producer";
+import { Config } from "../src/config";
 
-  return {
-    default: {
+describe("Producer", () => {
+  mock.module("node:https", () => {
+    const mockResponse = {
+      statusCode: 200,
+      statusMessage: "OK",
+      pipe: mock((stream) => {
+        // Simulate successful pipe operation
+        setTimeout(() => {
+          stream.emit("finish");
+        }, 10);
+        return stream;
+      }),
+    };
+
+    const mockRequest = {
+      on: mock(() => {
+        // Don't emit error by default for successful case
+        return mockRequest;
+      }),
+    };
+
+    return {
+      default: {
+        get: mock((url, options, callback) => {
+          // Call the callback with the mock response
+          if (typeof options === "function") {
+            // If options is actually the callback
+            options(mockResponse);
+          } else if (typeof callback === "function") {
+            callback(mockResponse);
+          }
+          return mockRequest;
+        }),
+      },
+    };
+  });
+
+  // Mock fs module
+  mock.module("node:fs", () => {
+    const mockWriteStream = {
+      on: mock((event, callback) => {
+        // Simulate successful events
+        if (event === "finish") {
+          setTimeout(callback, 10);
+        }
+        return mockWriteStream;
+      }),
+      close: mock(() => {}),
+      emit: mock(() => {}),
+    };
+
+    return {
       readFileSync: () => "Hello world. Mocked file content.",
       createWriteStream: mock(() => mockWriteStream),
       existsSync: mock(() => true),
@@ -25,53 +65,12 @@ mock.module("node:fs", () => {
         // Simulate successful unlink
         if (callback) callback();
       }),
-    },
-  };
-});
+    };
+  });
 
-mock.module("node:https", () => {
-  const mockResponse = {
-    statusCode: 200,
-    statusMessage: "OK",
-    pipe: mock((stream) => {
-      // Simulate successful pipe operation
-      setTimeout(() => {
-        stream.emit("finish");
-      }, 10);
-      return stream;
-    }),
-  };
-
-  const mockRequest = {
-    on: mock(() => {
-      // Don't emit error by default for successful case
-      return mockRequest;
-    }),
-  };
-
-  return {
-    default: {
-      get: mock((url, options, callback) => {
-        // Call the callback with the mock response
-        if (typeof options === "function") {
-          // If options is actually the callback
-          options(mockResponse);
-        } else if (typeof callback === "function") {
-          callback(mockResponse);
-        }
-        return mockRequest;
-      }),
-    },
-  };
-});
-
-import { Config } from "../src/config";
-import { Producer } from "../src/adapters/producer";
-import { CoT } from "@tak-ps/node-tak";
-
-describe("Producer", () => {
   afterAll(() => {
     mock.restore();
+    mock.clearAllMocks();
   });
 
   describe("local storage", () => {

--- a/tests/tak-client.spec.ts
+++ b/tests/tak-client.spec.ts
@@ -1,10 +1,10 @@
-import tls from "node:tls";
-import { describe, it, mock, expect, afterEach } from "bun:test";
-import { TakClient } from "../src/tak";
-import type { Config } from "../src/config";
 import CoT from "@tak-ps/node-cot";
-import { EventEmitter } from "node:events";
 import { sleep } from "bun";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { EventEmitter } from "node:events";
+import tls from "node:tls";
+import type { Config } from "../src/config";
+import { TakClient } from "../src/tak";
 
 const takConfig: Config = {
   dev: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     // Some stricter flags (disabled by default)
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitAny": true
+    "noImplicitAny": true,
+    "types": ["bun"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "index.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
### TL;DR

Pin Bun version to 1.2.20 and update dependencies to ensure compatibility.

### What changed?

- Added `configVersion: 0` to the lockfile
- Pinned Bun version to 1.2.20 in both package.json and dependencies
- Updated several dependencies to their latest compatible versions:
  - `@openaddresses/batch-error` to 2.13.1
  - `@sinclair/typebox` to 0.34.48
  - `@types/express` to 5.0.6
  - `@types/express-serve-static-core` to 5.1.1
  - `@types/serve-static` to 2.2.0
  - `protobufjs` to 7.5.4
- Enhanced the dev script with `--console-depth=10` for better debugging
- Improved imports organization in `src/config/index.ts`
- Added explicit `types: ["bun"]` to tsconfig.json

### How to test?

1. Run `bun install` to update dependencies
2. Verify the application starts correctly with `bun run start`
3. Test the development environment with `bun run dev`
4. Run tests with `bun test` to ensure everything works with the pinned Bun version

### Why make this change?

This change ensures consistent development environments by pinning the Bun version to 1.2.20 and updating dependencies to compatible versions. The explicit version pinning prevents unexpected behavior from automatic updates and ensures all team members use the same runtime environment. The console depth increase in the dev script improves debugging capabilities.