### PR TITLE
fix(logs): show partial chars in sanitized config values

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -177,18 +177,30 @@ export function getConfig(): Config {
     validatedConfig.cot_log_regex = process.env.COT_LOG_REGEX;
   }
 
+  const mask = (val: string): string => {
+    if (val.length <= 8) return "********";
+    if (val.length < 16) return val.slice(0, 1) + "********" + val.slice(-1);
+    return val.slice(0, 2) + "********" + val.slice(-2);
+  };
+
   const sanitizedConfig = structuredClone(validatedConfig);
-  sanitizedConfig.tak.key_file = "********";
-  sanitizedConfig.tak.cert_file = "********";
+  sanitizedConfig.tak.key_file = mask(sanitizedConfig.tak.key_file);
+  sanitizedConfig.tak.cert_file = mask(sanitizedConfig.tak.cert_file);
   if (sanitizedConfig.consumers) {
     sanitizedConfig.consumers.forEach((consumer) => {
-      consumer.catalyst_token = "********";
+      consumer.catalyst_token = mask(consumer.catalyst_token);
     });
   }
   if (sanitizedConfig.producer?.enabled === true) {
-    sanitizedConfig.producer.catalyst_jwt_issuer = "********";
-    sanitizedConfig.producer.catalyst_jwks_url = "********";
-    sanitizedConfig.producer.catalyst_app_id = "********";
+    sanitizedConfig.producer.catalyst_jwt_issuer = mask(
+      sanitizedConfig.producer.catalyst_jwt_issuer,
+    );
+    sanitizedConfig.producer.catalyst_jwks_url = mask(
+      sanitizedConfig.producer.catalyst_jwks_url,
+    );
+    sanitizedConfig.producer.catalyst_app_id = mask(
+      sanitizedConfig.producer.catalyst_app_id,
+    );
   }
   console.log("[CONFIG] Catalyst TAK Adapter Config", sanitizedConfig);
 


### PR DESCRIPTION
Tiered credential masking for config logging:
- ≤8 chars: fully masked ("********")
- 9-15 chars: 1 char each side (e.g. "c********n")
- 16+ chars: 2 chars each side (e.g. "ca********en")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how secrets are redacted in logged configuration by revealing a few leading/trailing characters, which slightly increases the chance of credential leakage via logs. Logic is small and localized to config logging.
> 
> **Overview**
> Updates config logging sanitization to use a new tiered `mask()` helper instead of fully replacing secrets with `"********"`.
> 
> When printing the sanitized config, `tak.key_file`, `tak.cert_file`, consumer `catalyst_token`, and producer Catalyst identifiers/URLs are now partially masked based on length (showing 0/1/2 chars at each edge) to aid debugging while still redacting most of the value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0b9e45f5ed0215d3a4692ff42f0d9ae6e85962a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->